### PR TITLE
Avoid deprecated headers in unit tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_COMPILE_IFELSE(
 )
 YAZ_DOC
 
-ID_BOOST([system thread test regex],[1.33])
+ID_BOOST([system thread test regex],[1.34])
 if test -z "${BOOST_THREAD_LIB}"; then
     AC_MSG_ERROR([Boost thread development libraries required])
 fi

--- a/doc/book.xml
+++ b/doc/book.xml
@@ -150,7 +150,7 @@
       <para>
        The popular C++ library. Initial versions of Metaproxy
        was built with 1.32 but this is no longer supported.
-       Metaproxy is known to work with Boost version 1.33 through 1.69.
+       Metaproxy is known to work with Boost version 1.34 through 1.74.
       </para>
      </listitem>
     </varlistentry>

--- a/src/test_boost_threads.cpp
+++ b/src/test_boost_threads.cpp
@@ -20,9 +20,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <list>
 #include <iostream>

--- a/src/test_filter1.cpp
+++ b/src/test_filter1.cpp
@@ -22,9 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <metaproxy/filter.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter2.cpp
+++ b/src/test_filter2.cpp
@@ -27,9 +27,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <iostream>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 

--- a/src/test_filter_auth_simple.cpp
+++ b/src/test_filter_auth_simple.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter_backend_test.cpp
+++ b/src/test_filter_backend_test.cpp
@@ -31,9 +31,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <yaz/pquery.h>
 #include <yaz/otherinfo.h>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 using namespace boost::unit_test;
 
 namespace mp = metaproxy_1;

--- a/src/test_filter_bounce.cpp
+++ b/src/test_filter_bounce.cpp
@@ -26,12 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <iostream>
 #include <stdexcept>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
-
-
-
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 

--- a/src/test_filter_factory.cpp
+++ b/src/test_filter_factory.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "factory_filter.hpp"
 
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter_frontend_net.cpp
+++ b/src/test_filter_frontend_net.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter_log.cpp
+++ b/src/test_filter_log.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter_multi.cpp
+++ b/src/test_filter_multi.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_filter_query_rewrite.cpp
+++ b/src/test_filter_query_rewrite.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 

--- a/src/test_filter_record_transform.cpp
+++ b/src/test_filter_record_transform.cpp
@@ -22,9 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <iostream>
 

--- a/src/test_filter_rewrite.cpp
+++ b/src/test_filter_rewrite.cpp
@@ -31,10 +31,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <yaz/log.h>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE( test_filter_rewrite_1 )
         mp::odr odr;
         Z_GDU *gdu_req = z_get_HTTP_Request_uri(odr,
             "https://proxyhost/proxypath/targetsite/page1.html", 0, 1);
-        
+
         Z_HTTP_Request *hreq = gdu_req->u.HTTP_Request;
         z_HTTP_header_set(odr, &hreq->headers,
                           "X-Metaproxy-SkipLink", ".* skiplink.com" );

--- a/src/test_filter_sru_to_z3950.cpp
+++ b/src/test_filter_sru_to_z3950.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <iostream>
 #include <stdexcept>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 

--- a/src/test_filter_virt_db.cpp
+++ b/src/test_filter_virt_db.cpp
@@ -28,9 +28,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <yaz/zgdu.h>
 #include <yaz/pquery.h>

--- a/src/test_filter_z3950_client.cpp
+++ b/src/test_filter_z3950_client.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/router_chain.hpp>
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <yaz/zgdu.h>
 #include <yaz/otherinfo.h>

--- a/src/test_html_parser.cpp
+++ b/src/test_html_parser.cpp
@@ -27,10 +27,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <yaz/log.h>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_package1.cpp
+++ b/src/test_package1.cpp
@@ -22,9 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <metaproxy/package.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_pipe.cpp
+++ b/src/test_pipe.cpp
@@ -38,9 +38,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <metaproxy/util.hpp>
 #include "pipe.hpp"
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_router_flexml.cpp
+++ b/src/test_router_flexml.cpp
@@ -24,9 +24,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "router_flexml.hpp"
 #include "factory_static.hpp"
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 

--- a/src/test_ses_map.cpp
+++ b/src/test_ses_map.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <boost/thread/thread.hpp>
 #include <boost/shared_ptr.hpp>
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <yaz/zgdu.h>
 #include <yaz/pquery.h>

--- a/src/test_session1.cpp
+++ b/src/test_session1.cpp
@@ -21,9 +21,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <iostream>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_session2.cpp
+++ b/src/test_session2.cpp
@@ -25,9 +25,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_thread_pool_observer.cpp
+++ b/src/test_thread_pool_observer.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "pipe.hpp"
 #include "thread_pool_observer.hpp"
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 using namespace yazpp_1;

--- a/src/test_util.cpp
+++ b/src/test_util.cpp
@@ -23,9 +23,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <metaproxy/util.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test;
 namespace mp = metaproxy_1;

--- a/src/test_xmlutil.cpp
+++ b/src/test_xmlutil.cpp
@@ -22,9 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <metaproxy/xmlutil.hpp>
 
-#define BOOST_AUTO_TEST_MAIN
+#define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <yaz/zgdu.h>
 #include <yaz/otherinfo.h>


### PR DESCRIPTION
Require Boost 1.34 or later. Until now, Boost 1.33 was still supported.