### PR TITLE
frontent_net: do not log when closing a session

### DIFF
--- a/src/filter_frontend_net.cpp
+++ b/src/filter_frontend_net.cpp
@@ -350,13 +350,6 @@ yazpp_1::IPDU_Observer *yf::FrontendNet::ZAssocChild::sessionNotify(
 yf::FrontendNet::ZAssocChild::~ZAssocChild()
 {
     int d = m_p->m_peerStat.remove(m_peer);
-    if (m_p->m_msg_config.length())
-    {
-        std::ostringstream os;
-        os  << m_p->m_msg_config << " "
-            << m_peer << " closing cnt=" << d;
-        yaz_log(YLOG_LOG, "%s", os.str().c_str());
-    }
 }
 
 void yf::FrontendNet::ZAssocChild::report(Z_HTTP_Request *hreq)

--- a/src/filter_frontend_net.cpp
+++ b/src/filter_frontend_net.cpp
@@ -349,7 +349,7 @@ yazpp_1::IPDU_Observer *yf::FrontendNet::ZAssocChild::sessionNotify(
 
 yf::FrontendNet::ZAssocChild::~ZAssocChild()
 {
-    int d = m_p->m_peerStat.remove(m_peer);
+    m_p->m_peerStat.remove(m_peer);
 }
 
 void yf::FrontendNet::ZAssocChild::report(Z_HTTP_Request *hreq)


### PR DESCRIPTION
It does not log when a session opens anyway. But logs, if configured, when a package is decoded (whether successful or not)