### PR TITLE
backend_test: return OPAC records

### DIFF
--- a/doc/backend_test.xml
+++ b/doc/backend_test.xml
@@ -24,7 +24,20 @@
  <refsect1><title>DESCRIPTION</title>
   <para>
    A pseudo Z39.50 server for test purposes.
-   Similar to yaz-ztest.
+   Similar to yaz-ztest. It responds to search requests with a fixed number of hits (42),
+   and to present requests with dummy records.
+  </para>
+  <para>
+   It supports record syntaxes XML (element set with prefix <literal>FF</literal>),
+   MARC21/USMARC (element set <literal>B</literal>, <literal>F</literal>) and
+   OPAC (element set <literal>B</literal>, <literal>F</literal>).
+   For element-set <literal>SD</literal>, a surrogate diagnostic is returned
+   for each record. In all other cases where diagnostics are returned, they are non-surrogate diagnostics.
+   The module is intended for testing the backend filter framework, and the test suite for this module
+   uses the test client to send requests and check the responses.
+  </para>
+  <para>
+   The module is not intended for production use.
   </para>
  </refsect1>
 

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -260,7 +260,7 @@ Z_Records *yf::BackendTest::Rep::fetch(
             memcpy(tmp_rec+186, offset_str, strlen(offset_str));
             if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_opac)) {
                 Z_OPACRecord *opac_rec = dummy_opac(offset_str, element_set_name, odr, tmp_rec);
-                npr->u.databaseRecord = z_ext_record_oid(odr, yaz_oid_recsyn_opac, (char*) opac_rec, -1);
+                npr->u.databaseRecord = z_ext_record_oid(odr, yaz_oid_recsyn_opac, (const char*) opac_rec, -1);
             }
             else
                 npr->u.databaseRecord = z_ext_record_usmarc(odr, tmp_rec, strlen(tmp_rec));

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -121,22 +121,21 @@ static Z_OPACRecord *dummy_opac(const char *item_id, const char *element_set_nam
         hr->which = Z_HoldingsRecord_holdingsAndCirc;
         hr->u.holdingsAndCirc = hc;
 
-        hc->typeOfRecord = (char *)"u";
+        hc->typeOfRecord = odr_strdup(odr, "u");
 
-        hc->encodingLevel = (char *)"u";
+        hc->encodingLevel = odr_strdup(odr, "u");
 
         hc->format = 0; /* OPT */
-        hc->receiptAcqStatus = (char *)"0";
+        hc->receiptAcqStatus = odr_strdup(odr, "0");
         hc->generalRetention = 0; /* OPT */
         hc->completeness = 0; /* OPT */
-        hc->dateOfReport = (char *)"000000";
-        hc->nucCode = (char *)"s-FM/GC";
-        hc->localLocation =
-            (char *)"Main or Science/Business Reading Rms - STORED OFFSITE";
+        hc->dateOfReport = odr_strdup(odr, "000000");
+        hc->nucCode = odr_strdup(odr, "s-FM/GC");
+        hc->localLocation = odr_strdup(odr, "Main or Science/Business Reading Rms - STORED OFFSITE");
         hc->shelvingLocation = 0; /* OPT */
-        hc->callNumber = (char *)"MLCM 89/00602 (N)";
-        hc->shelvingData = (char *)"FT MEADE";
-        hc->copyNumber = (char *)"Copy 1";
+        hc->callNumber = odr_strdup(odr, "MLCM 89/00602 (N)");
+        hc->shelvingData = odr_strdup(odr, "FT MEADE");
+        hc->copyNumber = odr_strdup(odr, "Copy 1");
         hc->publicNote = 0; /* OPT */
         hc->reproductionNote = 0; /* OPT */
         hc->termsUseRepro = 0; /* OPT */

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -231,9 +231,8 @@ Z_Records *yf::BackendTest::Rep::fetch(
                 zget_surrogateDiagRec(odr, 0, YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_,  "SD");
             continue;
         }
-        rec->u.databaseOrSurDiagnostics->records[i] = (Z_NamePlusRecord *)
-            odr_malloc(odr, sizeof(Z_NamePlusRecord));
-        Z_NamePlusRecord *npr = rec->u.databaseOrSurDiagnostics->records[i];
+        Z_NamePlusRecord *npr = (Z_NamePlusRecord *) odr_malloc(odr, sizeof(Z_NamePlusRecord));
+        rec->u.databaseOrSurDiagnostics->records[i] = npr;
         npr->databaseName = 0;
         npr->which = Z_NamePlusRecord_databaseRecord;
 

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -259,8 +259,8 @@ Z_Records *yf::BackendTest::Rep::fetch(
             snprintf(offset_str, sizeof offset_str, "test__%09d_", i+start);
             memcpy(tmp_rec+186, offset_str, strlen(offset_str));
             if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_opac)) {
-                Z_OPACRecord *rec = dummy_opac(offset_str, element_set_name, odr, tmp_rec);
-                npr->u.databaseRecord = z_ext_record_oid(odr, yaz_oid_recsyn_opac, (char*) rec, -1);
+                Z_OPACRecord *opac_rec = dummy_opac(offset_str, element_set_name, odr, tmp_rec);
+                npr->u.databaseRecord = z_ext_record_oid(odr, yaz_oid_recsyn_opac, (char*) opac_rec, -1);
             }
             else
                 npr->u.databaseRecord = z_ext_record_usmarc(odr, tmp_rec, strlen(tmp_rec));

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -130,7 +130,6 @@ Z_Records *yf::BackendTest::Rep::fetch(
         }
     }
 
-    // no element set, "B" and "F" are supported
     if (esn)
     {
         if (esn->which != Z_ElementSetNames_generic)
@@ -150,6 +149,8 @@ Z_Records *yf::BackendTest::Rep::fetch(
     else if (!strncmp(element_set_name, "FF", 2)
              && !oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_xml))
         ; // Huge XML test record
+    else if (!strcmp(element_set_name, "SD"))
+        ; // Surrogate diagnostic
     else
     {
         error_code
@@ -164,9 +165,13 @@ Z_Records *yf::BackendTest::Rep::fetch(
     rec->u.databaseOrSurDiagnostics->num_records = number;
     rec->u.databaseOrSurDiagnostics->records = (Z_NamePlusRecord **)
         odr_malloc(odr, sizeof(Z_NamePlusRecord *) * number);
-    int i;
-    for (i = 0; i<number; i++)
+    for (int i = 0; i < number; i++)
     {
+        if (!strcmp(element_set_name, "SD")) {
+            rec->u.databaseOrSurDiagnostics->records[i] =
+                zget_surrogateDiagRec(odr, 0, YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_,  "SD");
+            continue;
+        }
         rec->u.databaseOrSurDiagnostics->records[i] = (Z_NamePlusRecord *)
             odr_malloc(odr, sizeof(Z_NamePlusRecord));
         Z_NamePlusRecord *npr = rec->u.databaseOrSurDiagnostics->records[i];
@@ -174,11 +179,11 @@ Z_Records *yf::BackendTest::Rep::fetch(
         npr->which = Z_NamePlusRecord_databaseRecord;
 
         if (!strncmp(element_set_name, "FF", 2))
-        {   // Huge XML test record
+        {   // XML test record with optional size in kilo-bytes .. eg FF10 for 10KB
             size_t sz = 1024;
             if (element_set_name[2])
                 sz = atoi(element_set_name+2) * 1024;
-            if (sz < 10)
+            if (sz < 10 || sz > 1024*1024)
                 sz = 10;
             char *tmp_rec = (char*) xmalloc(sz);
 

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -100,36 +100,85 @@ yf::BackendTest::BackendTest() : m_p(new BackendTest::Rep) {
 yf::BackendTest::~BackendTest() {
 }
 
+
+Z_OPACRecord *dummy_opac(const char *item_id, const char *element_set_name, ODR odr, const char *marc_input)
+{
+    Z_OPACRecord *rec;
+    rec = (Z_OPACRecord *) odr_malloc(odr, sizeof(*rec));
+    rec->bibliographicRecord =
+        z_ext_record_usmarc(odr, marc_input, strlen(marc_input));
+    int availableNow = strcmp(element_set_name, "F") == 0;
+    rec->num_holdingsData = 1;
+    rec->holdingsData = (Z_HoldingsRecord **)
+        odr_malloc(odr, sizeof(*rec->holdingsData));
+    for (int i = 0; i < rec->num_holdingsData; i++)
+    {
+        Z_HoldingsRecord *hr = (Z_HoldingsRecord *)
+            odr_malloc(odr, sizeof(*hr));
+        Z_HoldingsAndCircData *hc = (Z_HoldingsAndCircData *)
+            odr_malloc(odr, sizeof(*hc));
+
+        rec->holdingsData[i] = hr;
+        hr->which = Z_HoldingsRecord_holdingsAndCirc;
+        hr->u.holdingsAndCirc = hc;
+
+        hc->typeOfRecord = (char *)"u";
+
+        hc->encodingLevel = (char *)"u";
+
+        hc->format = 0; /* OPT */
+        hc->receiptAcqStatus = (char *)"0";
+        hc->generalRetention = 0; /* OPT */
+        hc->completeness = 0; /* OPT */
+        hc->dateOfReport = (char *)"000000";
+        hc->nucCode = (char *)"s-FM/GC";
+        hc->localLocation =
+            (char *)"Main or Science/Business Reading Rms - STORED OFFSITE";
+        hc->shelvingLocation = 0; /* OPT */
+        hc->callNumber = (char *)"MLCM 89/00602 (N)";
+        hc->shelvingData = (char *)"FT MEADE";
+        hc->copyNumber = (char *)"Copy 1";
+        hc->publicNote = 0; /* OPT */
+        hc->reproductionNote = 0; /* OPT */
+        hc->termsUseRepro = 0; /* OPT */
+        hc->enumAndChron = 0; /* OPT */
+
+        hc->num_volumes = 0;
+        hc->volumes = 0;
+
+        hc->num_circulationData = 1;
+        hc->circulationData = (Z_CircRecord **)
+             odr_malloc(odr, sizeof(*hc->circulationData));
+        hc->circulationData[0] = (Z_CircRecord *)
+             odr_malloc(odr, sizeof(**hc->circulationData));
+
+        hc->circulationData[0]->availableNow = odr_booldup(odr, availableNow);
+        hc->circulationData[0]->availablityDate = 0;
+        hc->circulationData[0]->availableThru = 0;
+        hc->circulationData[0]->restrictions = 0;
+        hc->circulationData[0]->itemId = odr_strdup(odr, item_id);
+        hc->circulationData[0]->renewable = odr_booldup(odr, availableNow);
+        hc->circulationData[0]->onHold = odr_booldup(odr, !availableNow);
+        hc->circulationData[0]->enumAndChron = 0;
+        hc->circulationData[0]->midspine = 0;
+        hc->circulationData[0]->temporaryLocation = 0;
+    }
+    return rec;
+}
+
 Z_Records *yf::BackendTest::Rep::fetch(
     ODR odr, Odr_oid *preferredRecordSyntax,
     Z_ElementSetNames *esn,
     int start, int number, int &error_code, std::string &addinfo,
     int *number_returned, int *next_position)
 {
-    const char *element_set_name = "F"; // default to use
-
     if (number + start - 1 > result_set_size || start < 1)
     {
         error_code = YAZ_BIB1_PRESENT_REQUEST_OUT_OF_RANGE;
         return 0;
     }
 
-    if (!preferredRecordSyntax)
-        preferredRecordSyntax = odr_oiddup(odr, yaz_oid_recsyn_usmarc);
-
-    if (preferredRecordSyntax)
-    {
-        if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_xml))
-            ;
-        else if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_usmarc))
-            ;
-        else
-        {
-            error_code = YAZ_BIB1_RECORD_SYNTAX_UNSUPP;
-            return 0;
-        }
-    }
-
+    const char *element_set_name = "F"; // default to use
     if (esn)
     {
         if (esn->which != Z_ElementSetNames_generic)
@@ -140,22 +189,33 @@ Z_Records *yf::BackendTest::Rep::fetch(
         }
         element_set_name = esn->u.generic;
     }
-    if (!strcmp(element_set_name, "B")
-        && !oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_usmarc))
-        ; // Brief
-    else if (!strcmp(element_set_name, "F")
-             && !oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_usmarc))
-        ; // Full
-    else if (!strncmp(element_set_name, "FF", 2)
-             && !oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_xml))
-        ; // Huge XML test record
-    else if (!strcmp(element_set_name, "SD"))
-        ; // Surrogate diagnostic
+
+    if (!preferredRecordSyntax)
+        preferredRecordSyntax = odr_oiddup(odr, yaz_oid_recsyn_usmarc);
+
+    if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_xml))
+    {
+        if (strncmp(element_set_name, "FF", 2) && strcmp(element_set_name, "SD"))
+        {
+            error_code
+                = YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_;
+            addinfo = std::string(element_set_name);
+            return 0;
+        }
+    }
+    else if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_usmarc) || !oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_opac))
+    {
+        if (strcmp(element_set_name, "B") && strcmp(element_set_name, "F") && strcmp(element_set_name, "SD"))
+        {
+            error_code
+                = YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_;
+            addinfo = std::string(element_set_name);
+            return 0;
+        }
+    }
     else
     {
-        error_code
-            = YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_;
-        addinfo = std::string(element_set_name);
+        error_code = YAZ_BIB1_RECORD_SYNTAX_UNSUPP;
         return 0;
     }
     Z_Records *rec = (Z_Records *) odr_malloc(odr, sizeof(Z_Records));
@@ -200,8 +260,12 @@ Z_Records *yf::BackendTest::Rep::fetch(
             char offset_str[30];
             snprintf(offset_str, sizeof offset_str, "test__%09d_", i+start);
             memcpy(tmp_rec+186, offset_str, strlen(offset_str));
-            npr->u.databaseRecord = z_ext_record_usmarc(
-                odr, tmp_rec, strlen(tmp_rec));
+            if (!oid_oidcmp(preferredRecordSyntax, yaz_oid_recsyn_opac)) {
+                Z_OPACRecord *rec = dummy_opac(offset_str, element_set_name, odr, tmp_rec);
+                npr->u.databaseRecord = z_ext_record_oid(odr, yaz_oid_recsyn_opac, (char*) rec, -1);
+            }
+            else
+                npr->u.databaseRecord = z_ext_record_usmarc(odr, tmp_rec, strlen(tmp_rec));
         }
 
     }

--- a/src/filter_backend_test.cpp
+++ b/src/filter_backend_test.cpp
@@ -100,8 +100,7 @@ yf::BackendTest::BackendTest() : m_p(new BackendTest::Rep) {
 yf::BackendTest::~BackendTest() {
 }
 
-
-Z_OPACRecord *dummy_opac(const char *item_id, const char *element_set_name, ODR odr, const char *marc_input)
+static Z_OPACRecord *dummy_opac(const char *item_id, const char *element_set_name, ODR odr, const char *marc_input)
 {
     Z_OPACRecord *rec;
     rec = (Z_OPACRecord *) odr_malloc(odr, sizeof(*rec));

--- a/src/test_filter_backend_test.cpp
+++ b/src/test_filter_backend_test.cpp
@@ -109,6 +109,8 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
         if (z_gdu) {
             BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
             BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_searchResponse);
+            BOOST_CHECK_EQUAL(*z_gdu->u.z3950->u.searchResponse->resultCount, 42);
+            BOOST_CHECK(*z_gdu->u.z3950->u.searchResponse->searchStatus);
         }
 
         // present request no syntax, expecting usmarc record

--- a/src/test_filter_backend_test.cpp
+++ b/src/test_filter_backend_test.cpp
@@ -131,11 +131,11 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
             BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_presentResponse);
             Z_PresentResponse *resp = z_gdu->u.z3950->u.presentResponse;
             BOOST_CHECK(resp->records);
-            BOOST_CHECK(*resp->numberOfRecordsReturned == 1);
-            BOOST_CHECK(*resp->nextResultSetPosition == 2);
-            BOOST_CHECK(resp->records->which == Z_Records_DBOSD);
-            BOOST_CHECK(resp->records->u.databaseOrSurDiagnostics->num_records == 1);
-            BOOST_CHECK(resp->records->u.databaseOrSurDiagnostics->records[0]->which == Z_NamePlusRecord_databaseRecord);
+            BOOST_CHECK_EQUAL(*resp->numberOfRecordsReturned, 1);
+            BOOST_CHECK_EQUAL(*resp->nextResultSetPosition, 2);
+            BOOST_CHECK_EQUAL(resp->records->which, Z_Records_DBOSD);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->num_records, 1);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->records[0]->which, Z_NamePlusRecord_databaseRecord);
             Z_NamePlusRecord *npr = resp->records->u.databaseOrSurDiagnostics->records[0];
             BOOST_CHECK(npr->u.databaseRecord);
             BOOST_CHECK_EQUAL(npr->u.databaseRecord->which, Z_External_octet);

--- a/src/test_filter_backend_test.cpp
+++ b/src/test_filter_backend_test.cpp
@@ -30,6 +30,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <yaz/zgdu.h>
 #include <yaz/pquery.h>
 #include <yaz/otherinfo.h>
+#include <yaz/oid_std.h>
+#include <yaz/diagbib1.h>
 
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
@@ -38,7 +40,7 @@ using namespace boost::unit_test;
 
 namespace mp = metaproxy_1;
 
-BOOST_AUTO_TEST_CASE( test_filter_backend_test_1 )
+BOOST_AUTO_TEST_CASE( test_filter_backend_test_construct )
 {
     try
     {
@@ -49,7 +51,7 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_1 )
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_filter_backend_test_2 )
+BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
 {
     try
     {
@@ -81,13 +83,160 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_2 )
             BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
             BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_initResponse);
         }
+        apdu = zget_APDU(odr, Z_APDU_searchRequest);
+
+        mp::util::pqf(odr, apdu, "computer");
+
+        apdu->u.searchRequest->num_databaseNames = 1;
+        apdu->u.searchRequest->databaseNames = (char**)
+            odr_malloc(odr, sizeof(char *));
+        apdu->u.searchRequest->databaseNames[0] = odr_strdup(odr, "Default");
+
+        BOOST_CHECK(apdu);
+
+        pack.request() = apdu;
+
+        // Put it in router
+        pack.router(router).move();
+
+        // Inspect that we got response
+        gdu = &pack.response();
+
+        BOOST_CHECK(!pack.session().is_closed());
+
+        z_gdu = gdu->get();
+        BOOST_CHECK(z_gdu);
+        if (z_gdu) {
+            BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
+            BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_searchResponse);
+        }
+
+        // present request no syntax, expecing usmarc record
+        apdu = zget_APDU(odr, Z_APDU_presentRequest);
+        BOOST_CHECK(apdu);
+        apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
+        apdu->u.presentRequest->numberOfRecordsRequested = odr_intdup(odr, 1);
+
+        pack.request() = apdu;
+        pack.router(router).move();
+        gdu = &pack.response();
+        BOOST_CHECK(!pack.session().is_closed());
+
+        z_gdu = gdu->get();
+        BOOST_CHECK(z_gdu);
+        if (z_gdu) {
+            BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
+            BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_presentResponse);
+            Z_PresentResponse *resp = z_gdu->u.z3950->u.presentResponse;
+            BOOST_CHECK(resp->records);
+            BOOST_CHECK(*resp->numberOfRecordsReturned == 1);
+            BOOST_CHECK(*resp->nextResultSetPosition == 2);
+            BOOST_CHECK(resp->records->which == Z_Records_DBOSD);
+            BOOST_CHECK(resp->records->u.databaseOrSurDiagnostics->num_records == 1);
+            BOOST_CHECK(resp->records->u.databaseOrSurDiagnostics->records[0]->which == Z_NamePlusRecord_databaseRecord);
+            Z_NamePlusRecord *npr = resp->records->u.databaseOrSurDiagnostics->records[0];
+            BOOST_CHECK(npr->u.databaseRecord);
+            BOOST_CHECK_EQUAL(npr->u.databaseRecord->which, Z_External_octet);
+            BOOST_CHECK_EQUAL(oid_oidcmp(npr->u.databaseRecord->direct_reference, yaz_oid_recsyn_usmarc), 0);
+        }
+
+        // opac syntax, expecing usmarc record
+        apdu = zget_APDU(odr, Z_APDU_presentRequest);
+        BOOST_CHECK(apdu);
+        apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
+        apdu->u.presentRequest->numberOfRecordsRequested = odr_intdup(odr, 1);
+        apdu->u.presentRequest->preferredRecordSyntax = odr_oiddup(odr, yaz_oid_recsyn_opac);
+
+        pack.request() = apdu;
+        pack.router(router).move();
+        gdu = &pack.response();
+        BOOST_CHECK(!pack.session().is_closed());
+
+        z_gdu = gdu->get();
+        BOOST_CHECK(z_gdu);
+        if (z_gdu) {
+            BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
+            BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_presentResponse);
+            Z_PresentResponse *resp = z_gdu->u.z3950->u.presentResponse;
+            BOOST_CHECK(resp->records);
+            BOOST_CHECK_EQUAL(*resp->numberOfRecordsReturned, 1);
+            BOOST_CHECK_EQUAL(*resp->nextResultSetPosition, 2);
+            BOOST_CHECK_EQUAL(resp->records->which, Z_Records_DBOSD);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->num_records, 1);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->records[0]->which, Z_NamePlusRecord_databaseRecord);
+            Z_NamePlusRecord *npr = resp->records->u.databaseOrSurDiagnostics->records[0];
+            BOOST_CHECK(npr->u.databaseRecord);
+            BOOST_CHECK_EQUAL(npr->u.databaseRecord->which, Z_External_OPAC);
+            BOOST_CHECK_EQUAL(oid_oidcmp(npr->u.databaseRecord->direct_reference, yaz_oid_recsyn_opac), 0);
+        }
+
+        // danmarc syntax, expecing non surrogate diagnostic
+        apdu = zget_APDU(odr, Z_APDU_presentRequest);
+        BOOST_CHECK(apdu);
+        apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
+        apdu->u.presentRequest->numberOfRecordsRequested = odr_intdup(odr, 1);
+        apdu->u.presentRequest->preferredRecordSyntax = odr_oiddup(odr, yaz_oid_recsyn_danmarc);
+
+        pack.request() = apdu;
+        pack.router(router).move();
+        gdu = &pack.response();
+        BOOST_CHECK(!pack.session().is_closed());
+
+        z_gdu = gdu->get();
+        BOOST_CHECK(z_gdu);
+        if (z_gdu) {
+            BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
+            BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_presentResponse);
+            Z_PresentResponse *resp = z_gdu->u.z3950->u.presentResponse;
+            BOOST_CHECK(resp->records);
+            BOOST_CHECK_EQUAL(*resp->numberOfRecordsReturned, 0);
+            BOOST_CHECK_EQUAL(resp->records->which, Z_Records_NSD);
+            Z_DefaultDiagFormat *diag = resp->records->u.nonSurrogateDiagnostic;
+            BOOST_CHECK(diag);
+            BOOST_CHECK_EQUAL(diag->which, Z_DefaultDiagFormat_v2Addinfo);
+            BOOST_CHECK_EQUAL(*diag->condition, YAZ_BIB1_RECORD_SYNTAX_UNSUPP);
+        }
+
+        // present request to get surrogate diagnostic
+        apdu = zget_APDU(odr, Z_APDU_presentRequest);
+        BOOST_CHECK(apdu);
+        apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
+        apdu->u.presentRequest->numberOfRecordsRequested = odr_intdup(odr, 1);
+        apdu->u.presentRequest->recordComposition = (Z_RecordComposition *) odr_malloc(odr, sizeof(Z_RecordComposition));
+        apdu->u.presentRequest->recordComposition->which = Z_RecordComp_simple;
+        apdu->u.presentRequest->recordComposition->u.simple = (Z_ElementSetNames *) odr_malloc(odr, sizeof(Z_ElementSetNames));
+        apdu->u.presentRequest->recordComposition->u.simple->which = Z_ElementSetNames_generic;
+        apdu->u.presentRequest->recordComposition->u.simple->u.generic = odr_strdup(odr, "SD");
+
+        pack.request() = apdu;
+        pack.router(router).move();
+        gdu = &pack.response();
+        BOOST_CHECK(!pack.session().is_closed());
+
+        z_gdu = gdu->get();
+        BOOST_CHECK(z_gdu);
+        if (z_gdu) {
+            BOOST_CHECK_EQUAL(z_gdu->which, Z_GDU_Z3950);
+            BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_presentResponse);
+            Z_PresentResponse *resp = z_gdu->u.z3950->u.presentResponse;
+            BOOST_CHECK(resp->records);
+            BOOST_CHECK_EQUAL(*resp->numberOfRecordsReturned, 1);
+            BOOST_CHECK_EQUAL(*resp->nextResultSetPosition, 2);
+            BOOST_CHECK_EQUAL(resp->records->which, Z_Records_DBOSD);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->num_records, 1);
+            BOOST_CHECK_EQUAL(resp->records->u.databaseOrSurDiagnostics->records[0]->which, Z_NamePlusRecord_surrogateDiagnostic);
+            Z_DiagRec *diagRec = resp->records->u.databaseOrSurDiagnostics->records[0]->u.surrogateDiagnostic;
+            BOOST_CHECK(diagRec);
+            BOOST_CHECK_EQUAL(diagRec->which, Z_DiagRec_defaultFormat);
+            BOOST_CHECK_EQUAL(*diagRec->u.defaultFormat->condition, YAZ_BIB1_SPECIFIED_ELEMENT_SET_NAME_NOT_VALID_FOR_SPECIFIED_);
+        }
     }
     catch ( ... ) {
         BOOST_CHECK (false);
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_filter_backend_test_3 )
+BOOST_AUTO_TEST_CASE( test_filter_backend_test_no_init_search )
 {
     try
     {
@@ -134,7 +283,7 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_3 )
     }
 }
 
-BOOST_AUTO_TEST_CASE( test_filter_backend_test_4 )
+BOOST_AUTO_TEST_CASE( test_filter_backend_test_no_init_present )
 {
     try
     {

--- a/src/test_filter_backend_test.cpp
+++ b/src/test_filter_backend_test.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
             BOOST_CHECK_EQUAL(z_gdu->u.z3950->which, Z_APDU_searchResponse);
         }
 
-        // present request no syntax, expecing usmarc record
+        // present request no syntax, expecting usmarc record
         apdu = zget_APDU(odr, Z_APDU_presentRequest);
         BOOST_CHECK(apdu);
         apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
             BOOST_CHECK_EQUAL(oid_oidcmp(npr->u.databaseRecord->direct_reference, yaz_oid_recsyn_usmarc), 0);
         }
 
-        // opac syntax, expecing usmarc record
+        // opac syntax, expecting opac record
         apdu = zget_APDU(odr, Z_APDU_presentRequest);
         BOOST_CHECK(apdu);
         apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE( test_filter_backend_test_search_present )
             BOOST_CHECK_EQUAL(oid_oidcmp(npr->u.databaseRecord->direct_reference, yaz_oid_recsyn_opac), 0);
         }
 
-        // danmarc syntax, expecing non surrogate diagnostic
+        // danmarc syntax, expecting non surrogate diagnostic
         apdu = zget_APDU(odr, Z_APDU_presentRequest);
         BOOST_CHECK(apdu);
         apdu->u.presentRequest->resultSetStartPoint = odr_intdup(odr, 1);


### PR DESCRIPTION
Allow OPAC records to be returned. 

Extend the unit test of the backend_test filter quite a bit (which was almost non-existing already).